### PR TITLE
Bump sicmutils, convert to deps.edn

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,4 @@
+{:paths ["src"]
+ :deps {borkdude/sci {:mvn/version "0.2.5"}
+        thheller/shadow-cljs {:mvn/version "2.14.4"}
+        sicmutils/sicmutils {:mvn/version "0.19.1"}}}

--- a/deps.edn
+++ b/deps.edn
@@ -1,4 +1,4 @@
 {:paths ["src"]
  :deps {borkdude/sci {:mvn/version "0.2.5"}
         thheller/shadow-cljs {:mvn/version "2.14.4"}
-        sicmutils/sicmutils {:mvn/version "0.19.1"}}}
+        sicmutils/sicmutils {:mvn/version "0.19.2"}}}

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -1,26 +1,13 @@
-
-
-{
-    :builds {
-        :sicm-widget {
-            :asset-path "cljs_out"
-            :compiler-options {
-                :optimizations :advanced
-                :output-wrapper false
-                :pseudo-names true
-                :source-map true}
-            :devtools {
-                :http-root "."
-                :http-port 8700}
-            :modules {:main {:entries [repl.core]}}
-            :output-dir "cljs_out"
-            :target :browser
-        }
-    }
-    :dependencies [
-        [borkdude/sci "0.2.5"]
-        [sicmutils/sicmutils "0.19.0"]
-    ]
-    :dev-http {9000 "."}
-    :source-paths ["src"]
-}
+{:deps true
+ :builds {:sicm-widget
+          {:asset-path "cljs_out"
+           :compiler-options {:optimizations :advanced
+                              :output-wrapper false
+                              :pseudo-names true
+                              :source-map true}
+           :devtools {:http-root "."
+                      :http-port 8700}
+           :modules {:main {:entries [repl.core]}}
+           :output-dir "cljs_out"
+           :target :browser}}
+ :dev-http {9000 "."}}

--- a/src/repl/core.cljs
+++ b/src/repl/core.cljs
@@ -1,31 +1,31 @@
-; Module that contains the primary evaluation framework.
+;; Module that contains the primary evaluation framework.
 (ns repl.core
-  (:require
-    ["fraction.js/bigfraction.js" :as Fraction]
-    [sci.core :as sci]
-    [sicmutils.env]
-    [sicmutils.env.sci]
-    [sicmutils.expression.render]))
-
-;(def dummy (.div (.mul (Fraction 1 2) 3) 4)) ; Include to avoid build problems.
+  (:require ["fraction.js/bigfraction.js" :as Fraction]
+            [sicmutils.ratio]
+            [sci.core :as sci]
+            [sicmutils.env]
+            [sicmutils.env.sci]
+            [sicmutils.expression.render]))
 
 (defn pTeX [ex]
-    (-> ex sicmutils.env/simplify sicmutils.expression.render/->TeX js/outputTex))
+  (-> ex
+      (sicmutils.env/simplify)
+      (sicmutils.expression.render/->TeX)
+      (js/outputTex)))
 
-(def context-options {
-  :namespaces sicmutils.env.sci/namespaces
-  :bindings (
-    merge {
-      'pTeX pTeX
-    }
-    (sicmutils.env.sci/namespaces 'sicmutils.env))})
-(def sicm-context  (sci/init context-options))
+(def context-options
+  {:namespaces sicmutils.env.sci/namespaces
+   :bindings (merge {'pTeX pTeX}
+                    (sicmutils.env.sci/namespaces 'sicmutils.env))})
+
+(def sicm-context (sci/init context-options))
 
 (defn ^:export evalStr [source eval-cb]
-  (try 
-    (eval-cb (clj->js {:value
-      (sci/eval-string*  sicm-context source)}))
-    (catch js/Error e 
+  (try
+    (eval-cb (clj->js
+              {:value
+               (sci/eval-string* sicm-context source)}))
+    (catch js/Error e
       (eval-cb (clj->js {:error e})))))
 
 (js/log "...CLJS loading complete.")


### PR DESCRIPTION
This PR:

- Bumps sicmutils to the 0.19.2 release; this fixes all advanced compilation issues.
- converts the shadow-cljs build to use a `deps.edn`, as [described here](https://shadow-cljs.github.io/docs/UsersGuide.html#deps-edn). 
- Adds some formatting to the core namespace, and removes the line you had needed previously to make sure that advanced compilation worked.

The final build size is 2.5MB, or 539k when zipped (with `:pseudo-names true` removed, of course).

Feel free to ignore this and just bump on your own, if you don't want the formatting or `deps.edn` changes!

The `deps.edn` change was nice for debugging because I could replace the `sicmutils` dependency with

```
sicmutils/sicmutils {:local/root "../sicmutils"}
```

and see the effect of local changes to `sicmutils` on the project without having to round-trip through a publish.